### PR TITLE
Make `blockLock` pull a connection on each check

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,6 +25,7 @@ import           GHC.Generics
 import           Hedgehog                 as HH
 import qualified Hedgehog.Gen             as Gen
 import qualified Hedgehog.Range           as Range
+import           System.Timeout
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
 -------------------------------------------------------------------------------
@@ -48,6 +49,7 @@ tests c = testGroup "hedis-utils"
   , prop_blocklock_fail c
   , prop_blocklock c
   , prop_lock_expire c
+  , prop_blocklock_exhaustion
   ]
 
 
@@ -227,6 +229,34 @@ prop_fifo_custom c = testProperty "push/pop FIFO custom type" $ property $ do
   n === td
 
 
+-------------------------------------------------------------------------------
+prop_blocklock_exhaustion :: TestTree
+prop_blocklock_exhaustion = testProperty "blockLock does not hold a connection the entire time" $ property $ do
+  c1 <- liftIO $ connect defaultConnectInfo { connectMaxConnections = 1 }
+  l1 <- liftIO $ runRedis c1 $ acquireLock ns lockTime nm
+  unless l1 $ footnote "Failed to acquire initial lock"
+  HH.assert l1
 
+  blockAsync <- liftIO $ async $
+    runRedis c1 $ blockLock blockPolicy ns lockTime nm
+
+  stat <- liftIO $ timeout (secondsInMicros 1) $
+    runRedis c1 ping
+
+  unless (stat == Just (Right Pong)) $
+    footnote "Expected blockLock to not hold connection but it did"
+  stat === Just (Right Pong)
+
+  liftIO $ cancel blockAsync
+  liftIO $ runRedis c1 $ releaseLock ns nm
+  where
+    blockPolicy :: RetryPolicy
+    blockPolicy = capDelay (secondsInMicros 5) (exponentialBackoff 10000)
+    lockTime = 5
+    ns = "locktest"
+    nm = "blockLock"
+
+
+-------------------------------------------------------------------------------
 secondsInMicros :: Double -> Int
 secondsInMicros = round . (* 1e6)


### PR DESCRIPTION
This is going into a breaking change set. As I say in the commit, unfortunately, the `Redis` monad effectively maps to one connection being checked out, so there was no way for me to rewrite `blockLock` and keep the type. Instead, on each attempt to secure the lock according to the retry policy, it will pull a connection from the pool to avoid starving other threads.

The issue is that previously this would all happen with 1 connection, so a user may reasonably think `blockLock` merely stalls the thread waiting on the lock to free. Instead, it actually holds the connection outside the pool the entire time. If you do this enough times (50 with defaultConnectionInfo) with long retry waits, you can actually deplete the pool and block other threads. This isn't necessary as the connections aren't stateful and aren't doing anything with the connection while waiting.